### PR TITLE
TYPO3 6.1

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -37,7 +37,7 @@ $EM_CONF[$_EXTKEY] = array (
 		'depends' => 
 		array (
 			'php' => '5.2.0-6.0.0',
-			'typo3' => '4.4.0-6.0.99',
+			'typo3' => '4.4.0-6.1.99',
 		),
 		'conflicts' => 
 		array (


### PR DESCRIPTION
Set maximum compatibility to TYPO3 CMS version 6.1.
