### PR TITLE
Remove logout link

### DIFF
--- a/piwik_patches/plugins/TYPO3Login/TYPO3Login.php
+++ b/piwik_patches/plugins/TYPO3Login/TYPO3Login.php
@@ -65,9 +65,19 @@ class TYPO3Login extends \Piwik\Plugin
 			'Request.initAuthenticationObject'	    => 'initAuthenticationObject',
 			'User.isNotAuthorized'	            => 'noAccess',
 			'API.Request.authenticate'                      => 'ApiRequestAuthenticate',
+			'Menu.Add' => 'configureTopMenu',
 			'AssetManager.getJavaScriptFiles'  => 'getJsFiles'
 		);
 		return $hooks;
+	}
+
+	public function configureTopMenu(MenuTop $menu)
+	{
+		// Remove logout link from top-menu
+		//Params of $menu->remove($menuName, $subMenuName): 
+		//$menuName (string) — The menu's category name. Can be a translation token.
+		//$subMenuName (bool|string) — The menu item's name. Can be a translation token.
+		$menu->remove('General_Logout');
 	}
 
 	public function getJsFiles(&$jsFiles)

--- a/piwik_patches/plugins/TYPO3Login/TYPO3Login.php
+++ b/piwik_patches/plugins/TYPO3Login/TYPO3Login.php
@@ -74,9 +74,6 @@ class TYPO3Login extends \Piwik\Plugin
 	public function configureTopMenu(MenuTop $menu)
 	{
 		// Remove logout link from top-menu
-		//Params of $menu->remove($menuName, $subMenuName): 
-		//$menuName (string) — The menu's category name. Can be a translation token.
-		//$subMenuName (bool|string) — The menu item's name. Can be a translation token.
 		$menu->remove('General_Logout');
 	}
 


### PR DESCRIPTION
This should remove the logout link from the Piwik top menu. The line in configureTopMenu() and the function itself are correct. However, it seems like the function does not get called...

Maybe you can have a look at it, Kay?