### PR TITLE
Update for Piwik 2.16.2

### DIFF
--- a/Classes/Lib/Config.php
+++ b/Classes/Lib/Config.php
@@ -139,7 +139,7 @@ class tx_piwikintegration_config {
 		//General
 		$this->setOption('General', 'show_website_selector_in_user_interface', 0);
 		$this->setOption('General', 'serve_widget_and_data', 0);
-		$this->setOption('General', 'piwik_pro_ads_enabled', 0);
+		$this->setOption('General', 'piwik_professional_support_ads_enabled', 0);
 
 		//Disable the frame detection of Piwik
 		$this->setOption('General', 'enable_framed_pages', 1);
@@ -160,7 +160,7 @@ class tx_piwikintegration_config {
 		$this->disablePlugin('ExampleUI');
 		$this->disablePlugin('ExampleVisualization');
 		$this->disablePlugin('Login');
-		$this->disablePlugin('PiwikPro');
+		$this->disablePlugin('ProfessionalServices');
 		$this->enableSuggestedPlugins();
 
 		//create PiwikTables, check wether base tables already exist

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -27,7 +27,7 @@ $EM_CONF[$_EXTKEY] = array (
 	array (
 		'depends' =>
 		array (
-			'php' => '5.2.0-6.0.0',
+			'php' => '5.3.7-7.0.99',
 			'typo3' => '6.2.5-7.9.99',
 		),
 		'conflicts' =>


### PR DESCRIPTION
The plugin name PiwikPro and the configuration option name
piwik_pro_ads_enabled have been changed in Piwik 2.16.2. 

Update them.