### PR TITLE
[TASK] Remove obsolete TYPO3 config from TYPO3Login plugin

### DIFF
--- a/piwik_patches/plugins/TYPO3Login/Auth.php
+++ b/piwik_patches/plugins/TYPO3Login/Auth.php
@@ -26,33 +26,6 @@ namespace Piwik\Plugins\TYPO3Login;
 use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\UsersManager;
 
-/*
- * Fix some problems with external DB usage
- */
-
-    if (!defined('TYPO3_MODE')) {
-        define('TYPO3_MODE', 'BE');
-    }
-    if (file_exists(PIWIK_INCLUDE_PATH.'/../../LocalConfiguration.php')) {
-        $TYPO3config = include PIWIK_INCLUDE_PATH.'/../../LocalConfiguration.php';
-        // Try AdditionalConfiguration.php if database was not defined in LocalConfiguration.php
-        if (empty($TYPO3config['DB']['database']) && file_exists(PIWIK_INCLUDE_PATH.'/../../AdditionalConfiguration.php')) {
-            // Load AdditionalConfiguration.php via closure to avoid variable leak
-            call_user_func(function () use (&$TYPO3config) {
-                // Allow for e.g. array_merge calls within AdditionalConfiguration.php
-                $GLOBALS['TYPO3_CONF_VARS'] = $TYPO3config;
-                include PIWIK_INCLUDE_PATH.'/../../AdditionalConfiguration.php';
-                $TYPO3config['DB']['database'] = $GLOBALS['TYPO3_CONF_VARS']['DB']['database'];
-            });
-        }
-        define('TYPO3DB', $TYPO3config['DB']['database']);
-    } elseif (file_exists(PIWIK_INCLUDE_PATH.'/../../localconf.php')) {
-        include PIWIK_INCLUDE_PATH.'/../../localconf.php';
-        define('TYPO3DB', $typo_db);
-    } else {
-        throw new \Exception('Can´t include TYPO3-config file');
-    }
-
 /**
  * Provide authentification service against TYPO3 for piwik.
  *


### PR DESCRIPTION
The inclusion of the LocalConfiguration.php / localconf.php
files at the top of the piwik TYPO3Login plugin is removed.

The configuration is not needed any more and can cause problems
when symlinks are used.

Resolves: #75