### PR TITLE
Matomo 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Integrates Matomo into the TYPO3 Backend
 
-## This version of piwikintegration is compatible with Matomo 3.3 - 3.5.
+## This version of piwikintegration is compatible with Matomo 3.3 - 3.6.
 
 ![Build Status](https://travis-ci.org/kaystrobach/TYPO3.piwikintegration.svg)
 [![StyleCI](https://styleci.io/repos/8537360/shield?branch=master)](https://styleci.io/repos/8537360)


### PR DESCRIPTION
Updates for more secure cookie auth could still be incorporated, but it's working the classic way as well.