### PR TITLE
Replace $flashMessage->render()

### DIFF
--- a/Classes/Lib/Extmgm.php
+++ b/Classes/Lib/Extmgm.php
@@ -28,9 +28,9 @@ namespace KayStrobach\Piwikintegration\Lib;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * functions for the extmgm render forms and react on changes.
  *
@@ -134,6 +134,7 @@ class Extmgm
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
         $defaultFlashMessageQueue->enqueue($flashMessage);
+
         return $defaultFlashMessageQueue->renderFlashMessages();
     }
 }

--- a/Classes/Lib/Extmgm.php
+++ b/Classes/Lib/Extmgm.php
@@ -28,6 +28,9 @@ namespace KayStrobach\Piwikintegration\Lib;
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * functions for the extmgm render forms and react on changes.
  *
@@ -128,6 +131,9 @@ class Extmgm
             \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
         );
 
-        return $flashMessage->render();
+        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+        $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $defaultFlashMessageQueue->enqueue($flashMessage);
+        return $defaultFlashMessageQueue->renderFlashMessages();
     }
 }


### PR DESCRIPTION
This unbreaks extension configuration in the Install Tool in 9.5.