### PR TITLE
TemplateService->init() is removed in TYPO3 10

### DIFF
--- a/Classes/Lib/Div.php
+++ b/Classes/Lib/Div.php
@@ -111,7 +111,7 @@ class Div
         $template_uid = 0;
         $tmpl = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService');    // Defined global here!
             $tmpl->tt_track = 0;    // Do not log time-performance information
-            $tmpl->init();
+            $tmpl->__construct();   // Anyway...
 
         $tplRow = $tmpl->ext_getFirstTemplate($uid, $template_uid);
         if (is_array($tplRow) || 1) {    // IF there was a template...

--- a/Classes/Lib/Div.php
+++ b/Classes/Lib/Div.php
@@ -109,9 +109,8 @@ class Div
         }
         //parse ts template
         $template_uid = 0;
-        $tmpl = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\ExtendedTemplateService');    // Defined global here!
-            $tmpl->tt_track = 0;    // Do not log time-performance information
-            $tmpl->__construct();   // Anyway...
+        $tmpl = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\TypoScript\ExtendedTemplateService::class);    // Defined global here!
+        $tmpl->tt_track = 0;    // Do not log time-performance information
 
         $tplRow = $tmpl->ext_getFirstTemplate($uid, $template_uid);
         if (is_array($tplRow) || 1) {    // IF there was a template...

--- a/Classes/Lib/Div.php
+++ b/Classes/Lib/Div.php
@@ -110,7 +110,6 @@ class Div
         //parse ts template
         $template_uid = 0;
         $tmpl = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\TypoScript\ExtendedTemplateService::class);    // Defined global here!
-        $tmpl->tt_track = 0;    // Do not log time-performance information
 
         $tplRow = $tmpl->ext_getFirstTemplate($uid, $template_uid);
         if (is_array($tplRow) || 1) {    // IF there was a template...


### PR DESCRIPTION
TemplateService->init() will be removed in TYPO3 v10.0, __construct() does the job.