### PR TITLE
Make sure PIWIK_DOCUMENT_ROOT gets defined

### DIFF
--- a/Classes/Lib/Install.php
+++ b/Classes/Lib/Install.php
@@ -76,7 +76,7 @@ class Install
     /**
      * constructor to get a singleton.
      */
-    function __construct()
+    public function __construct()
     {
         try {
             $this->checkInstallation();

--- a/Classes/Lib/Install.php
+++ b/Classes/Lib/Install.php
@@ -74,9 +74,9 @@ class Install
     }
 
     /**
-     * private constructor to get a singleton.
+     * constructor to get a singleton.
      */
-    private function __construct()
+    function __construct()
     {
         try {
             $this->checkInstallation();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -96,17 +96,10 @@ $iconRegistry->registerIcon(
 );
 
 /******************************************************************************
- * load scheduler class if scheduler is installed
+ * Without this, PIWIK_DOCUMENT_ROOT would be undefined in FE calls since Matomo 3.12 and 3.13
  */
-
-/*
-if(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded ('scheduler') && $_EXTCONF['enableSchedulerTask']) {
-    //add task to scheduler list
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['KayStrobach\\Piwikintegration\\SchedulerTask\\Archive'] = array(
-            'extension'        => $_EXTKEY,
-            'title'            => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang.xml:piwikArchiveTask.name',
-            'description'      => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang.xml:piwikArchiveTask.description',
-            #'additionalFields' => 'tx_piwikintegration_piwikArchiveTask_AdditionalFieldProvider',
-    );
-    require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('piwikintegration', 'Classes/SchedulerTasks/Archive.php'));
-}*/
+if (!defined('PIWIK_DOCUMENT_ROOT')) {
+	$definition = new \KayStrobach\Piwikintegration\Lib\Install();
+	$path = $definition->getAbsInstallPath() . 'piwik';
+	define('PIWIK_DOCUMENT_ROOT', $path);
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -99,7 +99,7 @@ $iconRegistry->registerIcon(
  * Without this, PIWIK_DOCUMENT_ROOT would be undefined in FE calls since Matomo 3.12 and 3.13
  */
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
-	$definition = new \KayStrobach\Piwikintegration\Lib\Install();
-	$path = $definition->getAbsInstallPath() . 'piwik';
-	define('PIWIK_DOCUMENT_ROOT', $path);
+    $definition = new \KayStrobach\Piwikintegration\Lib\Install();
+    $path = $definition->getAbsInstallPath() . 'piwik';
+    define('PIWIK_DOCUMENT_ROOT', $path);
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -100,6 +100,6 @@ $iconRegistry->registerIcon(
  */
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
     $definition = new \KayStrobach\Piwikintegration\Lib\Install();
-    $path = $definition->getAbsInstallPath() . 'piwik';
+    $path = $definition->getAbsInstallPath().'piwik';
     define('PIWIK_DOCUMENT_ROOT', $path);
 }


### PR DESCRIPTION
https://github.com/matomo-org/matomo/pull/14866, which is part of Matomo 3.12 and 3.13, changes how constants are used by Matomo. Now PIWIK_DOCUMENT_ROOT needs to be defined manually for FE calls. Without this, calling a frontend site fails with the following PHP error: 

> Use of undefined constant PIWIK_DOCUMENT_ROOT - assumed 'PIWIK_DOCUMENT_ROOT' (this will throw an Error in a future version of PHP) in piwik\core\Config.php on line 111
> ...
> PHP Warning:  require(PIWIK_DOCUMENT_ROOT/config/global.php): failed to open stream: No such file or directory in ...

Make sure to define PIWIK_DOCUMENT_ROOT before it is used.